### PR TITLE
Patch 1 - Dependency fixes and LAM requiresReload

### DIFF
--- a/ImprovedTitleizer/ImprovedTitleizer.lua
+++ b/ImprovedTitleizer/ImprovedTitleizer.lua
@@ -7,7 +7,7 @@ local ImprovedTitleizer = {}
 ImprovedTitleizer.Name = "ImprovedTitleizer"
 ImprovedTitleizer.DisplayName = "Improved Titleizer"
 ImprovedTitleizer.Author = "tomstock, IsJustaGhost, Baertram[, Kyoma]"
-ImprovedTitleizer.Version = "1.9"
+ImprovedTitleizer.Version = "1.91"
 ImprovedTitleizer.DefSortByAchieveCat = true
 ImprovedTitleizer.DefShowMissingTitles = false
 
@@ -746,7 +746,8 @@ local function OnLoad(eventCode, name)
 			default = true,
 			getFunc = function() return ImprovedTitleizer.savedVariables.sortbyachievecat end,
 			setFunc = function( newValue ) ImprovedTitleizer.savedVariables.sortbyachievecat = newValue; ConstructTitleMenu() end,
-      warning = "Will need to reload the UI.",	--(optional)
+        		warning = "Will need to reload the UI.",	--(optional)
+			requiresReload = true,
 		},
 		{
 			type    = "checkbox",
@@ -754,7 +755,8 @@ local function OnLoad(eventCode, name)
 			default = true,
 			getFunc = function() return ImprovedTitleizer.savedVariables.showmissingtitles end,
 			setFunc = function( newValue ) ImprovedTitleizer.savedVariables.showmissingtitles = newValue; ConstructTitleMenu() end,
-      warning = "Will need to reload the UI.",	--(optional)
+      			warning = "Will need to reload the UI.",	--(optional)
+			requiresReload = true,
 		},
 	}
 	LAM = LibAddonMenu2

--- a/ImprovedTitleizer/ImprovedTitleizer.txt
+++ b/ImprovedTitleizer/ImprovedTitleizer.txt
@@ -11,6 +11,6 @@
 ## APIVersion: 101041 101042
 ## SavedVariables: ImprovedTitleizerSavedVariables
 ## OptionalDependsOn: LibDebugLogger
-## DependsOn: LibCustomMenu>=721 LibScrollableMenu>=0200 LibAddonMenu-2.0
+## DependsOn: LibAddonMenu-2.0>=36 LibScrollableMenu>=0200 
 
 ImprovedTitleizer.lua

--- a/ImprovedTitleizer/ImprovedTitleizer.txt
+++ b/ImprovedTitleizer/ImprovedTitleizer.txt
@@ -5,12 +5,12 @@
 
 ## Title: ImprovedTitleizer
 ## Description: This addon sorts the titles in your stat screen by name and also moves all pvp rank titles to a seperate submenu. Should work with all languages.
-## Version: 1.9
-## AddOnVersion:0109
+## Version: 1.91
+## AddOnVersion:010901
 ## Author: tomstock, IsJustaGhost, Baertram[, Kyoma]
 ## APIVersion: 101041 101042
 ## SavedVariables: ImprovedTitleizerSavedVariables
-## OptionalDependsOn: LibDebugLogger
+## OptionalDependsOn: LibDebugLogger>=263
 ## DependsOn: LibAddonMenu-2.0>=36 LibScrollableMenu>=0200 
 
 ImprovedTitleizer.lua


### PR DESCRIPTION
[Updated the dependencies]
--Removed LibCustomMenu as it is not needed anymore. Change the ESOUI description too and remove this dependency there.
It was replaced by LibScrollableMenu
--Added LibAddonMenu2.0>=26 version control so no old version could be loaded and errors
--Added optional dependency LibDebugLoggern version control so no old version could be loaded and errors

[Updated LAM panel options]
The options that showed a warning about requires a reload, will now use requiresReload = true.
This will make LAM show a button bottom right of the panel, if you changy any of the settings flagged for requiresReload = true.
If you click it your UI reloads.
If you leave the addon panel a popup dialog asks you if you want to apply the changed settings now and reload the UI or not. 
If you choose no the settings will be reverted back to old state.

-> This is just an idea, please test if it woks properly with your current setFunc -> Update of title menus
But should work fine.

-Increased the version to a subversion (minor change)

