### PR TITLE
Fixed param order of callback "NewStatusUpdated"

### DIFF
--- a/ImprovedTitleizer/ImprovedTitleizer.lua
+++ b/ImprovedTitleizer/ImprovedTitleizer.lua
@@ -7,7 +7,7 @@ local ImprovedTitleizer = {}
 ImprovedTitleizer.Name = "ImprovedTitleizer"
 ImprovedTitleizer.DisplayName = "Improved Titleizer"
 ImprovedTitleizer.Author = "tomstock, IsJustaGhost, Baertram[, Kyoma]"
-ImprovedTitleizer.Version = "1.9.3"
+ImprovedTitleizer.Version = "1.9.4"
 ImprovedTitleizer.DefSortByAchieveCat = true
 ImprovedTitleizer.DefShowMissingTitles = false
 
@@ -713,7 +713,7 @@ local function OnLoad(eventCode, name)
   SetupTitleEventManagement()
 
   --LibScrollableMenu
-  LSM:RegisterCallback('NewStatusUpdated', function(data, entry)
+  LSM:RegisterCallback('NewStatusUpdated', function(entry, data)
       -- This callback is fired on mouse-over of entries that were flagged as new.
       if newTitles[data.name] then
           newTitles[data.name] = nil

--- a/ImprovedTitleizer/ImprovedTitleizer.txt
+++ b/ImprovedTitleizer/ImprovedTitleizer.txt
@@ -5,8 +5,8 @@
 
 ## Title: ImprovedTitleizer
 ## Description: This addon sorts the titles in your stat screen by name and also moves all pvp rank titles to a seperate submenu. Should work with all languages.
-## Version: 1.9.3
-## AddOnVersion:010903
+## Version: 1.9.4
+## AddOnVersion:010904
 ## Author: tomstock, IsJustaGhost, Baertram[, Kyoma]
 ## APIVersion: 101041 101042
 ## SavedVariables: ImprovedTitleizerSavedVariables

--- a/ImprovedTitleizer/ImprovedTitleizer.txt
+++ b/ImprovedTitleizer/ImprovedTitleizer.txt
@@ -11,6 +11,6 @@
 ## APIVersion: 101041 101042
 ## SavedVariables: ImprovedTitleizerSavedVariables
 ## OptionalDependsOn: LibDebugLogger>=263
-## DependsOn: LibAddonMenu-2.0>=36 LibScrollableMenu>=0201
+## DependsOn: LibAddonMenu-2.0>=36 LibScrollableMenu>=0202
 
 ImprovedTitleizer.lua


### PR DESCRIPTION
LSM v2.2 harmoized the callback params to always start with the control (like ZOs code does), followed by the data 2nd. So this callback here needed the change from
NewStatusUpdated, data, control
NewStatusUpdated, control, data

Must be updated after LSM v2.2 was set live (planned for 2nd or 3rd June 2024).